### PR TITLE
fix gi errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dbus-python==1.2.4
 pympris==1.4
 pypresence==1.0.9
+pygobject==3.28.3


### PR DESCRIPTION
In case the environment doesn't have gobject installed (see: venv), adding this entry is helpful.